### PR TITLE
Update ruby-string-interpolation.cson

### DIFF
--- a/keymaps/ruby-string-interpolation.cson
+++ b/keymaps/ruby-string-interpolation.cson
@@ -7,6 +7,6 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.editor:not(.mini)':
+'atom-text-editor:not(.mini)':
   '#': 'ruby-string-interpolation:insert'
   'alt-3': 'ruby-string-interpolation:insert'


### PR DESCRIPTION
Use atome-text-editor in place of deprecated .editor
